### PR TITLE
Fix hmc leapfrog

### DIFF
--- a/MCMC.py
+++ b/MCMC.py
@@ -51,10 +51,10 @@ class HMCDiag:
         # TODO(bob-carpenter): refactor to share non-initial and non-final updates
         for n in range(self._steps):
             lp, grad = self._model.log_density_gradient(theta)
-            rho_mid = rho - 0.5 * self._stepsize * np.multiply(self._metric, grad)
+            rho_mid = rho + 0.5 * self._stepsize * np.multiply(self._metric, grad)
             theta = theta + self._stepsize * rho_mid
             lp, grad = self._model.log_density_gradient(theta)
-            rho = rho_mid - 0.5 * self._stepsize * np.multiply(self._metric, grad)
+            rho = rho_mid + 0.5 * self._stepsize * np.multiply(self._metric, grad)
         return (theta, rho)
 
     def sample(self):

--- a/example.py
+++ b/example.py
@@ -10,20 +10,21 @@ server = "stan/multi/multi"
 data = "stan/multi/multi.data.json"
 
 model = smc.StanClient(server, data=data, seed=1234)
+D = model.dims()
 
-stepsize = 1/64
-steps = 64
-metric_diag = [1, 1]
+stepsize = 0.25
+steps = 10
+metric_diag = [1] * D
 sampler = mcmc.HMCDiag(model, stepsize=stepsize, steps=steps, metric_diag=metric_diag)
 
 # works, but excruciatingly slow
-M = 10000
-theta = np.empty([M, 2])
+M = 1000
+theta = np.empty([M, D])
 for m in range(M):
     theta[m, :], _ = sampler.sample()
 
-
+print(theta.mean(0))
+print(theta.std(0))
 
 # proposal_rng = lambda: np.random.normal(size=model.dims())
 # sampler = mcmc.Metropolis(model, proposal_rng)
-


### PR DESCRIPTION
The HMC implementation on branch `main` subtracts in the momentum update of the leapfrog integrator.  Subtraction is appropriate when one negates the (joint) log density and its gradient, but Stan Model Server isn't doing this.  Instead one should add in the momentum updates.

This PR changes subtraction to addition in the leapfrog momentum updates, and better tunes the HMC run to the Stan model found in `stan/multi/multi.stan`, which `example.py` defaults to.

As empirical evidence of the addition, instead of the subtraction, here are four runs of the HMC example found in `example.py` for branch `main` and and this branch, both with improved tuning.

4 runs on `main`
```
(py3) ~/stan-model-server (main)% python example.py      
Mean estimate [-0.066  0.104], targeting [0, 0]
Std estimate [0.498 0.791], targeting [1, 1]

(py3) ~/stan-model-server (main)% python example.py
Mean estimate [-0.142  0.398], targeting [0, 0]
Std estimate [0.698 0.742], targeting [1, 1]

(py3) ~/stan-model-server (main)% python example.py
Mean estimate [0.184 0.246], targeting [0, 0]
Std estimate [1.758 0.615], targeting [1, 1]

(py3) ~/stan-model-server (main)% python example.py
Mean estimate [-0.155 -0.642], targeting [0, 0]
Std estimate [0.835 1.09 ], targeting [1, 1]
```

4 runs on this branch
```
(py3) ~/stan-model-server (fix-hmc-leapfrog)% python example.py
Mean estimate [-0.006  0.007], targeting [0, 0]
Std estimate [0.973 0.981], targeting [1, 1]

(py3) ~/stan-model-server (fix-hmc-leapfrog)% python example.py
Mean estimate [ 0.016 -0.005], targeting [0, 0]
Std estimate [0.988 0.991], targeting [1, 1]

(py3) ~/stan-model-server (fix-hmc-leapfrog)% python example.py
Mean estimate [0.018 0.013], targeting [0, 0]
Std estimate [1.024 0.987], targeting [1, 1]

(py3) ~/stan-model-server (fix-hmc-leapfrog)% python example.py
Mean estimate [ 0.008 -0.014], targeting [0, 0]
Std estimate [1.026 0.986], targeting [1, 1]
```