### PR TITLE
Add exe suffix for stanc on windows

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@
 ## include paths
 GITHUB ?= $(HOME)/github/
 CMDSTAN ?= $(GITHUB)stan-dev/cmdstan/
-STANC ?= $(CMDSTAN)bin/stanc
+STANC ?= $(CMDSTAN)bin/stanc$(EXE)
 STAN ?= $(CMDSTAN)stan/
 MATH ?= $(STAN)lib/stan_math/
 # TBB_TARGETS = $(MATH)lib/tbb/libtbb.dylib


### PR DESCRIPTION
On Windows, the stanc executable is not at `$CMDSTAN/bin/stanc`, but `$CMDSTAN/bin/stanc.exe`. This makes sure that stanc is found regardless of system.